### PR TITLE
fix: nu value across different variants 

### DIFF
--- a/implementation/sign/thmldsa/doc.go
+++ b/implementation/sign/thmldsa/doc.go
@@ -1,12 +1,7 @@
-// mldsa implements NIST post-quantum signature scheme ML-DSA (FIPS204)
+// Package thmldsa implements threshold signing for NIST ML-DSA (FIPS 204).
 //
-// Each of the three different security levels of ML-DSA is implemented by a
-// subpackage. For instance, mldsa44 can be found in
+// Each of the three parameter sets is implemented by a subpackage. For
+// instance, thmldsa44 can be found in
 //
-//	github.com/cloudflare/circl/sign/mldsa/mldsa44
-//
-// If your choice for mode is fixed compile-time, use the subpackages.
-// To choose a scheme at runtime, use the generic signatures API under
-//
-//	github.com/cloudflare/circl/sign/schemes
+//	https://github.com/Threshold-ML-DSA/Threshold-ML-DSA/tree/main/implementation/sign/thmldsa/thmldsa44
 package thmldsa

--- a/implementation/sign/thmldsa/thmldsa65/dilithium.go
+++ b/implementation/sign/thmldsa/thmldsa65/dilithium.go
@@ -26,7 +26,7 @@ const (
 	SignatureSize = internal.SignatureSize
 )
 
-// ThresholdParams contains parameters for threshold ML-DSA-44
+// ThresholdParams contains parameters for threshold ML-DSA-65
 type ThresholdParams internal.ThresholdParams
 
 func (params *ThresholdParams) ResponseSize() int {
@@ -37,7 +37,7 @@ func (params *ThresholdParams) CommitmentSize() int {
 	return int(params.K) * internal.SingleCommitmentSize
 }
 
-// GetThresholdParams returns recommended parameters for threshold ML-DSA-44
+// GetThresholdParams returns recommended parameters for threshold ML-DSA-65
 // given threshold T and total number of parties N.
 // Returns error if parameters are invalid.
 func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
@@ -49,10 +49,10 @@ func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
 	return &params, nil
 }
 
-// PublicKey is the type of ML-DSA-44 public key
+// PublicKey is the type of ML-DSA-65 public key
 type PublicKey internal.PublicKey
 
-// PrivateKey is the type of ML-DSA-44 private key
+// PrivateKey is the type of ML-DSA-65 private key
 type PrivateKey internal.PrivateKey
 
 // [THRESHOLD]
@@ -374,7 +374,7 @@ func (pk *PublicKey) MarshalBinary() ([]byte, error) {
 // Unpacks the public key from data.
 func (pk *PublicKey) UnmarshalBinary(data []byte) error {
 	if len(data) != PublicKeySize {
-		return errors.New("packed public key must be of mldsa44.PublicKeySize bytes")
+		return errors.New("packed public key must be of mldsa65.PublicKeySize bytes")
 	}
 	var buf [PublicKeySize]byte
 	copy(buf[:], data)
@@ -385,7 +385,7 @@ func (pk *PublicKey) UnmarshalBinary(data []byte) error {
 // // Unpacks the private key from data.
 // func (sk *PrivateKey) UnmarshalBinary(data []byte) error {
 // 	if len(data) != PrivateKeySize {
-// 		return errors.New("packed private key must be of mldsa44.PrivateKeySize bytes")
+// 		return errors.New("packed private key must be of mldsa65.PrivateKeySize bytes")
 // 	}
 // 	var buf [PrivateKeySize]byte
 // 	copy(buf[:], data)

--- a/implementation/sign/thmldsa/thmldsa65/dilithium_test.go
+++ b/implementation/sign/thmldsa/thmldsa65/dilithium_test.go
@@ -1,6 +1,6 @@
 // Code generated from pkg.templ.go. DO NOT EDIT.
 
-// mldsa65 implements NIST signature scheme ML-DSA-44 as defined in FIPS204.
+// mldsa65 implements NIST signature scheme ML-DSA-65 as defined in FIPS204.
 package thmldsa65
 
 import (

--- a/implementation/sign/thmldsa/thmldsa65/internal/dilithium.go
+++ b/implementation/sign/thmldsa/thmldsa65/internal/dilithium.go
@@ -88,7 +88,7 @@ type PrivateKey struct {
 	s2h VecK // NTT(s₂)
 }
 
-// ThresholdParams contains parameters for threshold ML-DSA-44
+// ThresholdParams contains parameters for threshold ML-DSA-65
 type ThresholdParams struct {
 	// T is the threshold - minimum number of parties needed to sign
 	T uint8
@@ -120,7 +120,7 @@ func defaultThresholdParams() *ThresholdParams {
 	}
 }
 
-// GetThresholdParams returns recommended parameters for threshold ML-DSA-44
+// GetThresholdParams returns recommended parameters for threshold ML-DSA-65
 // given threshold T and total number of parties N.
 // Returns error if parameters are invalid.
 func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
@@ -137,7 +137,7 @@ func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
 
 	var k uint16
 	var r, rPrime float64
-	nu := float64(3.)
+	nu := float64(6.)
 	if t == 2 && n == 2 { // N = 2
 		k = uint16(3)   // Number of iterations
 		r = 501495      // Primary radius

--- a/implementation/sign/thmldsa/thmldsa87/dilithium.go
+++ b/implementation/sign/thmldsa/thmldsa87/dilithium.go
@@ -26,7 +26,7 @@ const (
 	SignatureSize = internal.SignatureSize
 )
 
-// ThresholdParams contains parameters for threshold ML-DSA-44
+// ThresholdParams contains parameters for threshold ML-DSA-87
 type ThresholdParams internal.ThresholdParams
 
 func (params *ThresholdParams) ResponseSize() int {
@@ -37,7 +37,7 @@ func (params *ThresholdParams) CommitmentSize() int {
 	return int(params.K) * internal.SingleCommitmentSize
 }
 
-// GetThresholdParams returns recommended parameters for threshold ML-DSA-44
+// GetThresholdParams returns recommended parameters for threshold ML-DSA-87
 // given threshold T and total number of parties N.
 // Returns error if parameters are invalid.
 func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
@@ -49,10 +49,10 @@ func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
 	return &params, nil
 }
 
-// PublicKey is the type of ML-DSA-44 public key
+// PublicKey is the type of ML-DSA-87 public key
 type PublicKey internal.PublicKey
 
-// PrivateKey is the type of ML-DSA-44 private key
+// PrivateKey is the type of ML-DSA-87 private key
 type PrivateKey internal.PrivateKey
 
 // [THRESHOLD]
@@ -374,7 +374,7 @@ func (pk *PublicKey) MarshalBinary() ([]byte, error) {
 // Unpacks the public key from data.
 func (pk *PublicKey) UnmarshalBinary(data []byte) error {
 	if len(data) != PublicKeySize {
-		return errors.New("packed public key must be of mldsa44.PublicKeySize bytes")
+		return errors.New("packed public key must be of mldsa87.PublicKeySize bytes")
 	}
 	var buf [PublicKeySize]byte
 	copy(buf[:], data)
@@ -385,7 +385,7 @@ func (pk *PublicKey) UnmarshalBinary(data []byte) error {
 // // Unpacks the private key from data.
 // func (sk *PrivateKey) UnmarshalBinary(data []byte) error {
 // 	if len(data) != PrivateKeySize {
-// 		return errors.New("packed private key must be of mldsa44.PrivateKeySize bytes")
+// 		return errors.New("packed private key must be of mldsa87.PrivateKeySize bytes")
 // 	}
 // 	var buf [PrivateKeySize]byte
 // 	copy(buf[:], data)

--- a/implementation/sign/thmldsa/thmldsa87/internal/dilithium.go
+++ b/implementation/sign/thmldsa/thmldsa87/internal/dilithium.go
@@ -88,7 +88,7 @@ type PrivateKey struct {
 	s2h VecK // NTT(s₂)
 }
 
-// ThresholdParams contains parameters for threshold ML-DSA-44
+// ThresholdParams contains parameters for threshold ML-DSA-87
 type ThresholdParams struct {
 	// T is the threshold - minimum number of parties needed to sign
 	T uint8
@@ -120,7 +120,7 @@ func defaultThresholdParams() *ThresholdParams {
 	}
 }
 
-// GetThresholdParams returns recommended parameters for threshold ML-DSA-44
+// GetThresholdParams returns recommended parameters for threshold ML-DSA-87
 // given threshold T and total number of parties N.
 // Returns error if parameters are invalid.
 func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
@@ -137,7 +137,7 @@ func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
 
 	var k uint16
 	var r, rPrime float64
-	nu := float64(3.)
+	nu := float64(7.)
 	if t == 2 && n == 2 { // N = 2
 		k = uint16(3)   // Number of iterations
 		r = 503119      // Primary radius


### PR DESCRIPTION
The $\nu$ value used for the different variants is kept constant at $\nu = 3$. According to the paper [2026/013, Pag. 22 and 23](https://eprint.iacr.org/2026/013.pdf) it should be $\nu = 3, 6$ and $7$ for the $44, 65$ and $87$ variants, respectively. 

I also added some copy-paste typos fixes along the way.