### PR TITLE
fix: r and r_prime parameter swap

### DIFF
--- a/implementation/sign/thmldsa/thmldsa65/internal/dilithium.go
+++ b/implementation/sign/thmldsa/thmldsa65/internal/dilithium.go
@@ -144,8 +144,8 @@ func GetThresholdParams(t, n uint8) (*ThresholdParams, error) {
 		rPrime = 501613 // Secondary radius
 	} else if n == 3 { // N = 3
 		ks := []uint16{5, 9}
-		rs := []float64{540212, 540378}
-		rPs := []float64{510387, 510504}
+		rs := []float64{540212, 510387}
+		rPs := []float64{540378, 510504}
 		k = ks[t-2]
 		r = rs[t-2]
 		rPrime = rPs[t-2]


### PR DESCRIPTION
There is one `r_prime` value in the `MlDsa65` `N=3` table that is smaller than the corresponding `r` value. Since $M=(\frac{r'}{r})^{nl}>1$, it should be the other way around.

The values in [Fig. 10](https://eprint.iacr.org/2026/013.pdf) are correct, so its just a a copy-paste issue. 